### PR TITLE
UAR-1386: Person page error: At least one Employment Information must be entered.

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/document/rule/IdentityManagementPersonDocumentRule.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/document/rule/IdentityManagementPersonDocumentRule.java
@@ -352,7 +352,7 @@ public class IdentityManagementPersonDocumentRule extends TransactionalDocumentR
     	boolean valid = true;
     	int i = 0;
     	for (PersonDocumentAffiliation affiliation : affiliations) {
-	    		if (affiliation.getAffiliationType() .isEmploymentAffiliationType() && affiliation.getEmpInfos().isEmpty()) {
+	    		if (affiliation.getAffiliationType().isEmploymentAffiliationType() && affiliation.isDflt() && affiliation.getEmpInfos().isEmpty()) {
 			     		GlobalVariables.getMessageMap().putError("affiliations[" + i + "].affiliationTypeCode",RiceKeyConstants.ERROR_ONE_ITEM_REQUIRED, "Employment Information");
 			     		valid = false;
 	    		}


### PR DESCRIPTION
The fix requires the employment information not empty only for the default affiliation.
