### PR TITLE
UAF-560 Bug-Granted to Roles column on Responsibility Lookup is broken

### DIFF
--- a/kim/kim-impl/src/main/groovy/org/kuali/rice/kim/impl/responsibility/UberResponsibilityBo.groovy
+++ b/kim/kim-impl/src/main/groovy/org/kuali/rice/kim/impl/responsibility/UberResponsibilityBo.groovy
@@ -45,13 +45,12 @@ class UberResponsibilityBo extends ResponsibilityBo {
     public String getAssignedToRolesToDisplay() {
         StringBuffer assignedToRolesToDisplay = new StringBuffer()
         for (RoleBo roleImpl: assignedToRoles) {
-            assignedToRolesToDisplay.append(getRoleDetailsToDisplay(roleImpl))
+            assignedToRolesToDisplay.append(roleImpl.getNamespaceCode().trim())
+            .append(" ")
+            .append(roleImpl.getName().trim())
+            .append(KimConstants.KimUIConstants.COMMA_SEPARATOR)
         }
         return StringUtils.chomp(assignedToRolesToDisplay.toString(), KimConstants.KimUIConstants.COMMA_SEPARATOR)
-    }
-
-    public String getRoleDetailsToDisplay(RoleBo roleImpl) {
-        return roleImpl.getNamespaceCode().trim() + " " + roleImpl.getName().trim() + KimConstants.KimUIConstants.COMMA_SEPARATOR
     }
 }
 


### PR DESCRIPTION
Moved the line that generates the string to be displayed on the results page from the getRoleDetailsToDisplay method, then deleted that method.  Added the line to the location in the getAssignedToRolesToDisplay method that previously called the other method which generated the string.  The string is now appended together and displayed to the page.
