### PR TITLE
UAF-1030 - Person Maintenance Doc - Incorrect info populating fields.

### DIFF
--- a/impl/src/main/resources/META-INF/common-config-defaults.xml
+++ b/impl/src/main/resources/META-INF/common-config-defaults.xml
@@ -303,7 +303,6 @@
     	Individual fields (all instances of them on the page) can also be hidden by following this format:
     	"[documentClass].hidden".  The value of this should be a comma delimited list of the DD names of the fields.
      -->
-    <param name="org.kuali.rice.kim.bo.ui.PersonDocumentEmploymentInfo.hidden" override="false">baseSalaryAmount</param>
 	  <param name="kim.hide.PersonDocumentAddress.type" override="false">HM</param>
 	  <param name="kim.hide.PersonDocumentPhone.type" override="false">HM</param>
 

--- a/kim/kim-ldap/src/main/java/edu/arizona/kim/ldap/UaEntityEmploymentMapper.java
+++ b/kim/kim-ldap/src/main/java/edu/arizona/kim/ldap/UaEntityEmploymentMapper.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.coreservice.api.parameter.Parameter;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kim.api.identity.CodedAttribute;
@@ -82,12 +83,16 @@ public class UaEntityEmploymentMapper extends UaBaseMapper<List<EntityEmployment
 			employmentInfo.setEmployeeId(edsRecord.getEmplId());
 			employmentInfo.setActive(edsAff.isActive());
 			employmentInfo.setEmployeeStatus(CodedAttribute.Builder.create(edsAff.getStatusCode()));
-			employmentInfo.setPrimaryDepartmentCode(getConstants().getDefaultChartCode() + " " + edsAff.getDeptCode());
+			employmentInfo.setPrimaryDepartmentCode(getConstants().getDefaultChartCode() + "-" + edsAff.getDeptCode());
 			employmentInfo.setEmployeeType(CodedAttribute.Builder.create(edsAff.getEmployeeType()));
+
+			// UAF-1030 -- baseSalaryAmount should always show $0.00, and *not* mapped to the EDS value
+			employmentInfo.setBaseSalaryAmount(KualiDecimal.ZERO);
 
 			employments.add(employmentInfo);
 			affId++;
 		}
+
 
 		return employments;
 


### PR DESCRIPTION
Removing config line that turns display off salary field in KIM, adding explicit zeroing of baseSalaryAmount field, and replacing "space" char in department code that throws validation error.
