### PR TITLE
UAF-2252: Bug - Group document does not display chart and organization

### DIFF
--- a/impl/src/main/java/org/kuali/rice/kim/bo/ui/GroupDocumentMember.java
+++ b/impl/src/main/java/org/kuali/rice/kim/bo/ui/GroupDocumentMember.java
@@ -17,6 +17,7 @@ package org.kuali.rice.kim.bo.ui;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
 import org.kuali.rice.kim.api.KimConstants;
 
 import javax.persistence.Column;
@@ -56,6 +57,9 @@ public class GroupDocumentMember extends KimDocumentBoActiveToFromBase {
 	protected String memberName;
 	@Transient
 	protected String memberNamespaceCode;
+	@Type(type="yes_no")
+	@Column(name="EDIT_FLAG")
+	protected boolean edit;
 	
 	protected String memberFullName;
 
@@ -147,5 +151,15 @@ public class GroupDocumentMember extends KimDocumentBoActiveToFromBase {
 	 */
 	public void setMemberFullName(String memberFullName) {
 		this.memberFullName = memberFullName;
+	}
+
+	@Override
+	public boolean isEdit() {
+		return edit;
+	}
+
+	@Override
+	public void setEdit(boolean edit) {
+		this.edit = edit;
 	}
 }

--- a/impl/src/main/java/org/kuali/rice/kim/document/IdentityManagementGroupDocument.java
+++ b/impl/src/main/java/org/kuali/rice/kim/document/IdentityManagementGroupDocument.java
@@ -80,8 +80,8 @@ public class IdentityManagementGroupDocument extends IdentityManagementTypeAttri
 	@Type(type="yes_no")
 	@Column(name="ACTV_IND")
 	protected boolean active = true;
-
-	@Transient
+	@Type(type="yes_no")
+	@Column(name="EDIT_FLAG")
 	protected boolean editing;
 
 	@OneToMany(targetEntity = GroupDocumentMember.class, fetch = FetchType.EAGER, cascade=CascadeType.ALL)

--- a/impl/src/main/java/org/kuali/rice/kim/web/struts/action/IdentityManagementGroupDocumentAction.java
+++ b/impl/src/main/java/org/kuali/rice/kim/web/struts/action/IdentityManagementGroupDocumentAction.java
@@ -25,6 +25,7 @@ import org.kuali.rice.core.api.util.RiceKeyConstants;
 import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.kim.api.KimConstants;
 import org.kuali.rice.kim.api.group.Group;
+import org.kuali.rice.kim.api.identity.entity.Entity;
 import org.kuali.rice.kim.api.identity.principal.Principal;
 import org.kuali.rice.kim.api.role.Role;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
@@ -218,7 +219,7 @@ public class IdentityManagementGroupDocumentAction extends IdentityManagementDoc
         }
         
         //See if possible to grab details for Principal
-        if (StringUtils.isEmpty(newMember.getMemberId()) 
+        if (StringUtils.isEmpty(newMember.getMemberId())
         		&& StringUtils.isNotEmpty(newMember.getMemberName())
         		&& StringUtils.equals(newMember.getMemberTypeCode(), KimConstants.KimGroupMemberTypes.PRINCIPAL_MEMBER_TYPE.getCode())) {
         	Principal principal = KimApiServiceLocator.getIdentityService().getPrincipalByPrincipalName(newMember.getMemberName());
@@ -228,6 +229,14 @@ public class IdentityManagementGroupDocumentAction extends IdentityManagementDoc
         }
         if(checkKimDocumentGroupMember(newMember) && 
         		KRADServiceLocatorWeb.getKualiRuleService().applyRules(new AddGroupMemberEvent("", groupDocumentForm.getGroupDocument(), newMember))){
+
+			// Set member's fullname if possible
+			Entity entity = KimApiServiceLocator.getIdentityService().getEntityByPrincipalName(newMember.getMemberName());
+			if(entity != null) {
+				String fullName = entity.getDefaultName().getFirstName() + " " + entity.getDefaultName().getLastName();
+				newMember.setMemberFullName(fullName);
+			}
+
         	newMember.setDocumentNumber(groupDocumentForm.getDocument().getDocumentNumber());
         	groupDocumentForm.getGroupDocument().addMember(newMember);
 	        groupDocumentForm.setMember(groupDocumentForm.getGroupDocument().getBlankMember());

--- a/kim/kim-impl/src/main/resources/org/kuali/rice/kim/impl/config/OJB-repository-kim.xml
+++ b/kim/kim-impl/src/main/resources/org/kuali/rice/kim/impl/config/OJB-repository-kim.xml
@@ -1169,6 +1169,7 @@
     <field-descriptor name="active" column="ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"  />
     <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"  />
     <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true"  />
+    <field-descriptor name="editing" column="EDIT_FLAG" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"  />
    	<reference-descriptor name="documentHeader" class-ref="org.kuali.rice.krad.bo.DocumentHeader" auto-retrieve="true" auto-update="object" auto-delete="object">
        	<foreignkey field-ref="documentNumber" />
    	</reference-descriptor>
@@ -1191,6 +1192,7 @@
     <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" indexed="true" />
     <field-descriptor name="activeFromDate" column="ACTV_FRM_DT" jdbc-type="TIMESTAMP" />
     <field-descriptor name="activeToDate" column="ACTV_TO_DT" jdbc-type="TIMESTAMP" />
+    <field-descriptor name="edit" column="EDIT_FLAG" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"  />
   </class-descriptor>
 
   <class-descriptor class="org.kuali.rice.kim.bo.ui.GroupDocumentQualifier" table="KRIM_PND_GRP_ATTR_DATA_T">

--- a/kim/kim-ldap/src/main/java/org/kuali/rice/kim/dao/impl/LdapPrincipalDaoImpl.java
+++ b/kim/kim-ldap/src/main/java/org/kuali/rice/kim/dao/impl/LdapPrincipalDaoImpl.java
@@ -306,7 +306,7 @@ public class LdapPrincipalDaoImpl implements LdapPrincipalDao {
         }
 
         Map<String, Object> criteria = new HashMap();
-        String key = getLdapAttribute(getKimConstants().getKimLdapIdProperty());
+        String key = getKimConstants().getKimLdapIdProperty();
         criteria.put(key, principalIds);
         return search(Principal.class, criteria);
     }

--- a/web/src/main/webapp/WEB-INF/tags/kim/groupAttributes.tag
+++ b/web/src/main/webapp/WEB-INF/tags/kim/groupAttributes.tag
@@ -40,7 +40,7 @@
             <c:set var="attrReadOnly" value="${(readOnly || (attrDefinition.unique && KualiForm.document.editing))}"/>
             <td align="left" valign="middle">
               <div align="center">
-                <c:if test="${not empty document.qualifiers[statusQualifier.index]}">
+                <c:if test="${not empty KualiForm.document.qualifiers[statusQualifier.index]}">
                   <kul:htmlControlAttribute property="document.qualifiers[${statusQualifier.index}].attrVal"
                                             attributeEntry="${attrEntry}" readOnly="${attrReadOnly}"/>
                 </c:if>


### PR DESCRIPTION
- groupAttributes.tag
  - Corrected JSP EL test that didn't contain full variable, which would fail and then not print actual property value, or HTML controls when creating new group document
- GroupDocumentMember.java
  - Added missing OJB member, necessitated by DB constraint
- IdentityManagementGroupDocument.java
  - Annotated OJB property in order to propagate when JPA in use, also visual queue that member is DB necessitated
- IdentityManagementGroupDocumentAction.java
  - Added logic to set Principal full name when new member being added, this is used by the associated tag in the view, of which the display is new in KFS 6
- OJB-repository-kim.xml
  - Added mapping entries for missing "edit" column in two classes, necessitated by DB constraints
- LdapPrincipalDaoImpl.java
  - Removed LDAP property name translation, which was causing group type membership to fail
