### PR TITLE
UAF-711 There were two issues with this ticket. First was the one sta…

### DIFF
--- a/impl/src/main/java/org/kuali/rice/kew/routeheader/DocumentRouteHeaderValue.java
+++ b/impl/src/main/java/org/kuali/rice/kew/routeheader/DocumentRouteHeaderValue.java
@@ -213,6 +213,8 @@ public class DocumentRouteHeaderValue extends PersistableBusinessObjectBase impl
     private boolean routingReport = false;
     @Transient
     private List<ActionRequestValue> simulatedActionRequests;
+    @Transient
+    private List<ActionTakenValue> actionsTaken = new ArrayList<ActionTakenValue>();
 
     private static final boolean FINAL_STATE = true;
     protected static final HashMap<String,String> legalActions;
@@ -344,7 +346,10 @@ public class DocumentRouteHeaderValue extends PersistableBusinessObjectBase impl
     }
 
     public List<ActionTakenValue> getActionsTaken() {
-       return (List<ActionTakenValue>) KEWServiceLocator.getActionTakenService().findByDocumentIdIgnoreCurrentInd(documentId);
+    	if(actionsTaken == null || actionsTaken.isEmpty()) {
+    		actionsTaken = (List<ActionTakenValue>) KEWServiceLocator.getActionTakenService().findByDocumentIdIgnoreCurrentInd(documentId);
+    	}
+    	return actionsTaken;
     }
 
     public List<ActionRequestValue> getActionRequests() {


### PR DESCRIPTION
…ted in the Jira, that the delegate is appearing as an FYI for the Account Supervisor instead of the Fiscal Officer. What was happening is that in the applyDelegationsToRoleMembers method of RoleServiceImpl.java, roleMembershipIdToBuilders is a HashMap. When looping through the roleMemberships, if the key (in this case, roleMembership.getId()) is the same, then the value will be overridden, so the order the roleMemberships come in is important. The order in this case, the roleId of the first roleMembership was 41 (Fiscal Officer) and the second roleMembership was 9 (Account Supervisor). The id for both was an asterisk (*). The second time through the loop, roleMembershipIdToBuilders already has an entry e.g. [*, builder1] so at line 995 it overrides the Map with [*, builder2]. After that, it applies the delegate to the wrong role (i.e. 9 instead of 41). So, I found the newest version of rice (2.5.12) and looked at the applyDelegationsToRoleMembers of RoleServiceImpl.java. The issue seemed to be addressed. In the comments it said, 'Modified the roleMembershipIdToBuilders map to be multi-valued so role members that have multiple nested members (e.g. roles/groups) will properly resolve the delegations'. This assigned the delegate to the Fiscal Officer (which is correct), but was still assigning the delegate to the Account Supervisor (which is incorrect). It was indiscriminately adding the delegate to all roles. I added a check to make sure the roleId of the delegation and the roleId of roleMembershipBuilder match before calling the linkDelegateToRoleMembership method. The second issue is that the Actions Taken section of the Route Log was displaying incorrectly. The issue here is that the getActionsTaken method in DocumentRouteHeaderValue.java always returns the same thing. In RouteLogAction.java, the actionRequest is passed into the switchActionRequestPositionIfPrimaryDelegatePresent method and switches the positions (if applicable).  However, when RouteLog.jsp gets the actonsTaken in line 117, it calls getActionsTaken that is calling the service and will return the original actionsTaken without the switched positions.  To fix this, I added a class variable actionsTaken. In the getActionsTaken method, set acttionsTaken to what's returned from the service if it's empty or null, otherwise return it as is. This will capture the changes made from switching the positions