### PR TITLE
UAF-4775 - Adding DD Doc Search result limit that matches KFS.

### DIFF
--- a/impl/src/main/resources/org/kuali/rice/kew/impl/document/search/DocumentSearchCriteriaBo.xml
+++ b/impl/src/main/resources/org/kuali/rice/kew/impl/document/search/DocumentSearchCriteriaBo.xml
@@ -406,6 +406,7 @@
       </list>
     </property>
     <property name="title" value="Document Search"/>
+    <property name="resultSetLimit" value="250"/>
   </bean>
   
 </beans>


### PR DESCRIPTION
Rice's RESULTS_LIMIT parm is set to 1k, but the KFS equivalent is set to 250. The limit works, but an idiosyncrasy with Rice prevents "total count" from being displayed if the result number is with the interval of (250, 1000).

This change adds a DataDictionary change, which gets picked up before the parm will. In such a way, we ensure the doc search displays "total count" when intended, but without globally changing the Rice.