### PR TITLE
UAF-5162 exclude servlet-api from core-filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2620,6 +2620,12 @@
         <groupId>co.kuali</groupId>
         <artifactId>core-filter</artifactId>
         <version>${core-auth-servlet-filter.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Cleaner Rice startup, no longer emits a warning about a jar file it cannot load