### PR TITLE
UAF-5246 Fixed KFS7 STG Roles Generate EDS Error

### DIFF
--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kim/service/impl/UaUiDocumentServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kim/service/impl/UaUiDocumentServiceImpl.java
@@ -6,18 +6,28 @@
 package edu.arizona.rice.kim.service.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import org.kuali.rice.core.api.membership.MemberType;
+import org.kuali.rice.kim.api.KimConstants;
 import org.kuali.rice.kim.api.group.Group;
 import org.kuali.rice.kim.api.group.GroupMember;
+import org.kuali.rice.kim.api.identity.entity.EntityDefault;
 import org.kuali.rice.kim.api.identity.principal.PrincipalContract;
+import org.kuali.rice.kim.bo.ui.KimDocumentRoleMember;
+import org.kuali.rice.kim.document.IdentityManagementRoleDocument;
 import org.kuali.rice.kim.impl.KIMPropertyConstants;
 import org.kuali.rice.kim.impl.identity.principal.PrincipalBo;
+import org.kuali.rice.kim.impl.role.RoleMemberBo;
 import org.kuali.rice.kim.service.impl.UiDocumentServiceImpl;
+import org.kuali.rice.krad.util.KRADPropertyConstants;
+import org.kuali.rice.krad.util.KRADUtils;
 
 import edu.arizona.rice.kim.document.UaIdentityManagementPersonDocument;
 
@@ -30,7 +40,7 @@ import edu.arizona.rice.kim.document.UaIdentityManagementPersonDocument;
 public class UaUiDocumentServiceImpl extends UiDocumentServiceImpl {
 	@SuppressWarnings("unused")
 	private static final Logger LOG = Logger.getLogger(UiDocumentServiceImpl.class);
-
+	
 	/**
 	 * Looks up GroupInfo objects for each group id passed in
 	 * 
@@ -79,5 +89,103 @@ public class UaUiDocumentServiceImpl extends UiDocumentServiceImpl {
 	protected boolean isCurrentOrFutureGroupMember(GroupMember member, DateTime today) {
 		return member.getActiveToDate() == null || today.compareTo(member.getActiveToDate()) < 0;
 	}
+
+	/** 
+	 * UA KFS7 upgrade. (UAF-5246) Overriding loadRoleMembers since editing role runs into 'java.lang.UnsupportedOperationException: This method is not supported under the UA EDS MOD" per UAF-5246
+	 * Changed to use new API added to IdentityService to allow loading Person information from EDS
+	 */
+	@Override
+	protected List<KimDocumentRoleMember> loadRoleMembers(
+            IdentityManagementRoleDocument identityManagementRoleDocument, List<RoleMemberBo> members){
+        List<KimDocumentRoleMember> pndMembers = new ArrayList<KimDocumentRoleMember>();
+
+        if(KRADUtils.isNull(members) || members.isEmpty() ){
+            return pndMembers;
+        }
+
+        // extract all the principal role member IDs
+        List<String> roleMemberPrincipalIds = new ArrayList<String>();
+        for(RoleMemberBo roleMember : members) {
+            if (roleMember.getType().getCode().equals(KimConstants.KimGroupMemberTypes.PRINCIPAL_MEMBER_TYPE.getCode())) {
+                if (!roleMemberPrincipalIds.contains(roleMember.getMemberId())) {
+                    roleMemberPrincipalIds.add(roleMember.getMemberId());
+                }
+            }
+        }
+
+        // pull in all the names for the principals for later use
+        Map<String, EntityDefault> principalIdToEntityMap = new HashMap<String,EntityDefault>();
+        /*KULRICE-12538: If roleMemberPrincipalIds is empty, skip populating list of pricipals*/
+        if(!roleMemberPrincipalIds.isEmpty()){
+        	// UA KFS7 upgrade. (UAF-5246) Use new API to load Person information from EDS
+            Map<String, String> criteria = new HashMap<String, String>();
+            
+            StringBuffer sb = new StringBuffer();
+            for (String principalId : roleMemberPrincipalIds) {
+				sb.append( principalId + "|");
+			}
+            
+            String principalIds = sb.toString();
+            if (StringUtils.endsWith(principalIds, "|")) {
+            	principalIds = StringUtils.substringBeforeLast(principalIds, "|");
+            }
+            
+			// add the list of principal IDs to the lookup so that only matching Person objects are returned
+			criteria.put( KIMPropertyConstants.Person.PRINCIPAL_ID, principalIds );
+			criteria.put("principals." + KRADPropertyConstants.ACTIVE, "Y");
+
+    		List<EntityDefault> entities = getIdentityService().findEntityDefaultsByCriteriaMap(criteria);
+            principalIdToEntityMap = new HashMap<String,EntityDefault>( entities.size() );
+            for ( EntityDefault entity : entities ) {
+                // yes, I'm missing null checks, but since I searched on principal ID - there needs to be
+                // at least one record
+                principalIdToEntityMap.put( entity.getPrincipals().get(0).getPrincipalId(), entity );
+            }
+            // END UA KFS7 upgrade changes
+        }
+        // pull in all the group members of this role
+        Map<String, Group> roleGroupMembers = findGroupsForRole(identityManagementRoleDocument.getRoleId());
+
+        for(RoleMemberBo member: members){
+            KimDocumentRoleMember pndMember = new KimDocumentRoleMember();
+            pndMember.setActiveFromDate(member.getActiveFromDateValue());
+            pndMember.setActiveToDate(member.getActiveToDateValue());
+            pndMember.setActive(member.isActive( getDateTimeService().getCurrentTimestamp()));
+            if(pndMember.isActive()){
+                pndMember.setRoleMemberId(member.getId());
+                pndMember.setRoleId(member.getRoleId());
+                pndMember.setMemberTypeCode(member.getType().getCode());
+                pndMember.setMemberId(member.getMemberId());
+                pndMember.setMemberNamespaceCode(getMemberNamespaceCode(member.getType(), member.getMemberId()));
+
+                if ( StringUtils.equals( pndMember.getMemberTypeCode(), MemberType.PRINCIPAL.getCode() ) ) {
+                    EntityDefault entity = principalIdToEntityMap.get(member.getMemberId());
+                    if ( entity != null ) {
+                        pndMember.setMemberName(entity.getPrincipals().get(0).getPrincipalName());
+
+                        if ( entity.getName() != null ) {
+                            pndMember.setMemberFullName(entity.getName().getFirstName() + " " + entity.getName().getLastName());
+                        }
+                    }
+                } else if ( StringUtils.equals( pndMember.getMemberTypeCode(), MemberType.GROUP.getCode() ) ) {
+                    Group group =  roleGroupMembers.get(member.getMemberId());
+                    if (group != null) {
+                        pndMember.setMemberName(group.getName());
+                        pndMember.setMemberNamespaceCode(group.getNamespaceCode());
+                        pndMember.setMemberFullName(group.getName());
+                    }
+                } else if ( StringUtils.equals( pndMember.getMemberTypeCode(), MemberType.ROLE.getCode() ) ) {
+                    pndMember.setMemberName(getMemberName(member.getType(), member.getMemberId()));
+                    pndMember.setMemberFullName(getMemberFullName(member.getType(), member.getMemberId()));
+                }
+
+                pndMember.setQualifiers(loadRoleMemberQualifiers(identityManagementRoleDocument, member.getAttributeDetails()));
+                pndMember.setEdit(true);
+                pndMembers.add(pndMember);
+            }
+        }
+        Collections.sort(pndMembers, identityManagementRoleDocument.getMemberMetaDataType());
+        return pndMembers;
+    }
 
 }

--- a/rice-middleware/kim/kim-api/src/main/java/org/kuali/rice/kim/api/identity/IdentityService.java
+++ b/rice-middleware/kim/kim-api/src/main/java/org/kuali/rice/kim/api/identity/IdentityService.java
@@ -1334,4 +1334,16 @@ public interface IdentityService {
     @WebMethod(operationName = "findPrincipals")
     @WebResult(name = "results")
     PrincipalQueryResults findPrincipals(@WebParam(name = "query") QueryByCriteria query)  throws RiceIllegalArgumentException;
+    
+    /**
+     * UA KFS7 upgrade. (UAF-5246) Adding EDS API to allow loading Person information from EDS. This method finds EntityDefault data based on a query criteria. 
+     * This is replacement of method EntityDefaultQueryResults findEntityDefaults(@WebParam(name = "query") QueryByCriteria query) 
+     *
+     * @param query the criteria.  
+     * @return query results.  
+     */
+    @WebMethod(operationName = "findEntityDefaultsByCriteriaMap")
+    @WebResult(name = "results")
+    List<EntityDefault> findEntityDefaultsByCriteriaMap( Map<String, String> criteria);
+
 }

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/identity/IdentityCurrentAndArchivedServiceImpl.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/identity/IdentityCurrentAndArchivedServiceImpl.java
@@ -667,4 +667,11 @@ public class IdentityCurrentAndArchivedServiceImpl implements IdentityService {
 	private IdentityArchiveService getIdentityArchiveService() {
 		return identityArchiveService;
 	}
+	
+	/**
+     * UA KFS7 upgrade. (UAF-5246) new API for loading person information from EDS 
+     */
+    public List<EntityDefault> findEntityDefaultsByCriteriaMap(Map<String, String> criteria) {
+    	return new ArrayList<EntityDefault>();
+    }
 }

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/identity/IdentityServiceImpl.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/identity/IdentityServiceImpl.java
@@ -1801,4 +1801,11 @@ public class IdentityServiceImpl implements IdentityService {
     public void setIdentityServiceDao(IdentityServiceDao identityServiceDao) {
         this.identityServiceDao = identityServiceDao;
     }
+    
+    /**
+     * UA KFS7 upgrade. (UAF-5246) new API for loading person information from EDS
+     */
+    public List<EntityDefault> findEntityDefaultsByCriteriaMap(Map<String, String> criteria) {
+    	return new ArrayList<EntityDefault>();
+    }
 }

--- a/rice-middleware/kim/kim-impl/src/main/resources/org/kuali/rice/kim/impl/config/KimWebSpringBeans.xml
+++ b/rice-middleware/kim/kim-impl/src/main/resources/org/kuali/rice/kim/impl/config/KimWebSpringBeans.xml
@@ -121,8 +121,9 @@
 	</bean>
   
   <!-- hack end -->
-  
-  <bean id="kimUiDocumentService" class="org.kuali.rice.kim.service.impl.UiDocumentServiceImpl" />
+  <!-- UA KFS7 upgrade. (UAF-5246) Redefine UiDocumentService to allow loading Person information from EDS instead of KIM -->
+  <!-- bean id="kimUiDocumentService" class="org.kuali.rice.kim.service.impl.UiDocumentServiceImpl" /-->
+  <bean id="kimUiDocumentService" class="edu.arizona.rice.kim.service.impl.UaUiDocumentServiceImpl" />
 
     <bean id="groupLookupable" class="org.kuali.rice.kim.lookup.GroupLookupableImpl" parent="kualiLookupable" scope="prototype">
         <property name="lookupableHelperService">

--- a/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/service/impl/UaLdapIdentityServiceImpl.java
+++ b/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/service/impl/UaLdapIdentityServiceImpl.java
@@ -758,13 +758,21 @@ public class UaLdapIdentityServiceImpl extends IdentityServiceImpl implements Ld
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);
     }
 
+    /**
+     * UA KFS7 upgrade. (UAF-5246) new API for loading person information from EDS
+     */
+    @Override
+    public List<EntityDefault> findEntityDefaultsByCriteriaMap( Map<String, String> criteria) {
+    	return findEntityDefaults(criteria, false);
+    }
+
     @Override
     public EntityDefaultQueryResults findEntityDefaults( QueryByCriteria queryByCriteria) {
         // Reject for reason #2
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);
     }
 
-    @Override
+	@Override
     public EntityQueryResults findEntities(QueryByCriteria queryByCriteria) {
         // Reject for reason #2
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MSG);


### PR DESCRIPTION
In KFS7 STG, edit role document generated EDS error of 'java.lang.UnsupportedOperationException: This method is not supported under the UA EDS MOD'. The error is due to unimplemented IdentityService API of EntityDefaultQueryResults findEntityDefaults( QueryByCriteria queryByCriteria) in UaLdapIdentityServiceImpl. To implement this API, it needs to process RICE KIM DTO QueryByCriteria  and EntityDefaultQueryResults. Current LDAP EDS access is not compatible with those DTO. The fix is to add new KIM API to IdentityService to allow access using existing EDS DAO.  Also modified and overrode UiDocumentService#loadRoleMembers in UaUiDocumentServiceImpl to change to use EDS compatible new API.  