### PR TITLE
UAF-66 - Extending DocumentRouteHeaderValue for new Externalized BO to serve over KSB.

### DIFF
--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEbo.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEbo.java
@@ -1,0 +1,14 @@
+package edu.arizona.rice.kew.routeheader;
+
+import org.kuali.rice.krad.bo.ExternalizableBusinessObject;
+
+public interface DocumentRouteHeaderValueEbo extends ExternalizableBusinessObject {
+
+    String getDocumentId();
+
+    String getDocumentTypeId();
+
+    String getDocRouteStatus();
+
+    java.sql.Timestamp getFinalizedDate();
+}

--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEboImpl.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEboImpl.java
@@ -1,0 +1,46 @@
+package edu.arizona.rice.kew.routeheader;
+
+import javax.persistence.Entity;
+
+import edu.arizona.rice.kew.api.routeheader.DocumentRouteHeaderValueContract;
+
+/**
+ * This class is overriden in order to expose DocumentRouteHeaderValue as an
+ * Externalizable Business Object (EBO). This then makes the underlying BO
+ * avaiable to the KSB, thus available to KFS while Rice is in standalone
+ * mode.
+ */
+@Entity
+public class DocumentRouteHeaderValueEboImpl extends org.kuali.rice.kew.routeheader.DocumentRouteHeaderValue implements DocumentRouteHeaderValueEbo, DocumentRouteHeaderValueContract {
+    private static final long serialVersionUID = 4527977459578527106L;
+
+    public static edu.arizona.rice.kew.api.routeheader.DocumentRouteHeaderValue to(DocumentRouteHeaderValueEboImpl documentRouteHeaderValue) {
+        if (documentRouteHeaderValue == null) {
+            return null;
+        }
+        edu.arizona.rice.kew.api.routeheader.DocumentRouteHeaderValue.Builder builder = edu.arizona.rice.kew.api.routeheader.DocumentRouteHeaderValue.Builder.create(documentRouteHeaderValue);
+
+        return builder.build();
+    }
+
+
+    public static DocumentRouteHeaderValueEboImpl from(DocumentRouteHeaderValueContract contract) {
+        if (contract == null) {
+            return null;
+        }
+
+        DocumentRouteHeaderValueEboImpl docRouteHeader = new DocumentRouteHeaderValueEboImpl();
+        docRouteHeader.setDocumentTypeId(contract.getDocumentTypeId());
+        docRouteHeader.setDocRouteStatus(contract.getDocRouteStatus());
+        docRouteHeader.setFinalizedDate(contract.getFinalizedDate());
+
+        return docRouteHeader;
+    }
+
+
+    @Override
+    public String getId() {
+        return getDocumentId();
+    }
+
+}

--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEboImpl.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEboImpl.java
@@ -30,6 +30,7 @@ public class DocumentRouteHeaderValueEboImpl extends org.kuali.rice.kew.routehea
         }
 
         DocumentRouteHeaderValueEboImpl docRouteHeader = new DocumentRouteHeaderValueEboImpl();
+        docRouteHeader.setDocumentId(contract.getDocumentId());
         docRouteHeader.setDocumentTypeId(contract.getDocumentTypeId());
         docRouteHeader.setDocRouteStatus(contract.getDocRouteStatus());
         docRouteHeader.setFinalizedDate(contract.getFinalizedDate());

--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/service/impl/KEWModuleService.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/service/impl/KEWModuleService.java
@@ -1,0 +1,29 @@
+package edu.arizona.rice.kew.service.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.rice.krad.bo.ExternalizableBusinessObject;
+
+import edu.arizona.rice.kew.routeheader.DocumentRouteHeaderValueEboImpl;
+
+public class KEWModuleService extends org.kuali.rice.kew.service.impl.KEWModuleService {
+
+    @SuppressWarnings({"deprecation", "unchecked"})//EBO, cast of return type
+    @Override
+    public <T extends ExternalizableBusinessObject> List<T> getExternalizableBusinessObjectsList(Class<T> businessObjectClass, Map<String, Object> fieldValues) {
+        if (businessObjectClass.isAssignableFrom(DocumentRouteHeaderValueEboImpl.class)) {
+            Map<String, String> castValueMap = new HashMap<>();
+            for (String key : fieldValues.keySet()) {
+                castValueMap.put(key, (String)fieldValues.get(key));
+            }
+
+            return (List<T>) getLookupService().findCollectionBySearch(DocumentRouteHeaderValueEboImpl.class, castValueMap);
+        } else {
+            // Default to super when not our special case
+            return super.getExternalizableBusinessObjectsList(businessObjectClass, fieldValues);
+        }
+    }
+
+}

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/routeheader/DocumentRouteHeaderValue.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/routeheader/DocumentRouteHeaderValue.java
@@ -69,6 +69,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.MappedSuperclass;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
 import javax.persistence.NamedEntityGraphs;
@@ -124,6 +125,7 @@ import java.util.Map;
  */
 @Entity
 @Table(name="KREW_DOC_HDR_T")
+@MappedSuperclass
 @NamedQueries({
     @NamedQuery(name=QuickLinksDAOJpa.FIND_WATCHED_DOCUMENTS_BY_INITIATOR_WORKFLOW_ID_NAME,
             query= QuickLinksDAOJpa.FIND_WATCHED_DOCUMENTS_BY_INITIATOR_WORKFLOW_ID_QUERY),

--- a/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/config/KewEmbeddedSpringBeans.xml
+++ b/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/config/KewEmbeddedSpringBeans.xml
@@ -358,7 +358,7 @@
     <property name="serviceName" value="persistenceServiceOjb"/>
   </bean>
 
-  <bean id="kewModule" class="org.kuali.rice.kew.service.impl.KEWModuleService">
+  <bean id="kewModule" class="edu.arizona.rice.kew.service.impl.KEWModuleService">
     <property name="moduleConfiguration" ref="kewModuleConfiguration"/>
     <property name="kualiModuleService" ref="rice.kew.import.kualiModuleService"/>
   </bean>
@@ -397,6 +397,7 @@
     <property name="packagePrefixes">
       <list>
         <value>org.kuali.rice.kew.</value>
+        <value>edu.arizona.rice.kew.</value>
       </list>
     </property>
     <property name="externalizableBusinessObjectImplementations">
@@ -404,6 +405,8 @@
         <entry key="org.kuali.rice.kew.doctype.bo.DocumentTypeEBO" value="org.kuali.rice.kew.doctype.bo.DocumentType"/>
         <entry key="org.kuali.rice.kew.docsearch.DocumentSearchCriteriaEbo"
                value="org.kuali.rice.kew.impl.document.search.DocumentSearchCriteriaBo"/>
+        <entry key="edu.arizona.rice.kew.routeheader.DocumentRouteHeaderValueEbo"
+               value="edu.arizona.rice.kew.routeheader.DocumentRouteHeaderValueEboImpl"/>
       </map>
     </property>
     <property name="providers">

--- a/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/config/KewRemoteSpringBeans.xml
+++ b/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/config/KewRemoteSpringBeans.xml
@@ -61,6 +61,8 @@
         <entry key="org.kuali.rice.kew.doctype.bo.DocumentTypeEBO" value="org.kuali.rice.kew.doctype.bo.DocumentType"/>
         <entry key="org.kuali.rice.kew.docsearch.DocumentSearchCriteriaEbo"
                value="org.kuali.rice.kew.impl.document.search.DocumentSearchCriteriaBo"/>
+        <entry key="edu.arizona.rice.kew.routeheader.DocumentRouteHeaderValueEbo"
+               value="edu.arizona.rice.kew.routeheader.DocumentRouteHeaderValueEboImpl"/>
       </map>
     </property>
   </bean>

--- a/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/config/_KewJpaSpringBeans.xml
+++ b/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/config/_KewJpaSpringBeans.xml
@@ -88,6 +88,7 @@
     <value>org.kuali.rice.kew.impl.type.KewTypeBo</value>
     <value>org.kuali.rice.kew.impl.type.KewTypeAttributeBo</value>
     <value>org.kuali.rice.kew.impl.type.KewAttributeDefinitionBo</value>
+    <value>edu.arizona.rice.kew.routeheader.DocumentRouteHeaderValueEboImpl</value>
   </util:list>
 
   <util:list id="additionalMetadataProviders" />

--- a/rice-middleware/kew/api/src/main/java/edu/arizona/rice/kew/api/routeheader/DocumentRouteHeaderValue.java
+++ b/rice-middleware/kew/api/src/main/java/edu/arizona/rice/kew/api/routeheader/DocumentRouteHeaderValue.java
@@ -1,0 +1,218 @@
+package edu.arizona.rice.kew.api.routeheader;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.kuali.rice.core.api.CoreConstants;
+import org.kuali.rice.core.api.mo.AbstractDataTransferObject;
+import org.kuali.rice.core.api.mo.ModelBuilder;
+import org.kuali.rice.kew.api.KewApiConstants;
+
+
+
+@XmlRootElement(name = DocumentRouteHeaderValue.Constants.ROOT_ELEMENT_NAME)
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(name = DocumentRouteHeaderValue.Constants.TYPE_NAME, propOrder = {
+        DocumentRouteHeaderValue.Elements.ID,
+        CoreConstants.CommonElements.VERSION_NUMBER,
+        DocumentRouteHeaderValue.Elements.DOCUMENT_ID,
+        DocumentRouteHeaderValue.Elements.DOCUMENT_TYPE_ID,
+        DocumentRouteHeaderValue.Elements.DOC_ROUTE_STATUS,
+        DocumentRouteHeaderValue.Elements.FINALIZED_DATE,
+        CoreConstants.CommonElements.FUTURE_ELEMENTS
+})
+public class DocumentRouteHeaderValue extends AbstractDataTransferObject implements DocumentRouteHeaderValueContract {
+    private static final long serialVersionUID = -1234724890181802996L;
+
+    @XmlElement(name = DocumentRouteHeaderValue.Elements.ID)
+    private String id;
+    @XmlElement(name = CoreConstants.CommonElements.VERSION_NUMBER)
+    private Long versionNumber;
+    @XmlElement(name = Elements.DOCUMENT_ID, required = true)
+    private String documentId;
+    @XmlElement(name = Elements.DOCUMENT_TYPE_ID, required = true)
+    private String documentTypeId;
+    @XmlElement(name = Elements.DOCUMENT_TYPE_ID, required = true)
+    private String docRouteStatus;
+    @XmlElement(name = Elements.FINALIZED_DATE)
+    private Timestamp finalizedDate;
+
+
+    /**
+     * Private constructor used only by JAXB.
+     */
+    private DocumentRouteHeaderValue() {
+        this.id = null;
+        this.versionNumber = null;
+        this.documentId = null;
+        this.documentTypeId = null;
+        this.docRouteStatus = null;
+        this.finalizedDate = null;
+    }
+
+
+    private DocumentRouteHeaderValue(Builder builder) {
+        this.id = builder.getId();
+        this.versionNumber = builder.getVersionNumber();
+        this.documentId = builder.getDocumentId();
+        this.documentTypeId = builder.getDocumentTypeId();
+        this.docRouteStatus = builder.getDocRouteStatus();
+        this.finalizedDate = builder.getFinalizedDate();
+    }
+
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+
+    @Override
+    public Long getVersionNumber() {
+        return versionNumber;
+    }
+
+
+    @Override
+    public String getDocumentId() {
+        return documentId;
+    }
+
+
+    @Override
+    public String getDocumentTypeId() {
+        return documentTypeId;
+    }
+
+
+    @Override
+    public String getDocRouteStatus() {
+        return docRouteStatus;
+    }
+
+
+    @Override
+    public Timestamp getFinalizedDate() {
+        return finalizedDate;
+    }
+
+
+    public static class Cache {
+        public static final String NAME = KewApiConstants.Namespaces.KEW_NAMESPACE_2_0 + "/" + Constants.TYPE_NAME;
+    }
+
+
+    public final static class Builder implements Serializable, ModelBuilder, DocumentRouteHeaderValueContract {
+        private static final long serialVersionUID = 6621024337713773145L;
+
+        private String id;
+        private Long versionNumber;
+        private String documentId;
+        private String documentTypeId;
+        private String docRouteStatus;
+        private Timestamp finalizedDate;
+
+        private Builder(String documentId) {
+            setDocumentId(documentId);
+        }
+
+
+        @Override
+        public DocumentRouteHeaderValue build() {
+            return new DocumentRouteHeaderValue(this);
+        }
+
+
+        public static Builder create(DocumentRouteHeaderValueContract contract) {
+            if (contract == null) {
+                throw new IllegalArgumentException("Passed in contract cannot be null!");
+            }
+
+            Builder builder = new Builder(contract.getDocumentId());
+            builder.setDocumentTypeId(contract.getDocumentTypeId());
+            builder.setDocRouteStatus(contract.getDocRouteStatus());
+            builder.setFinalizedDate(contract.getFinalizedDate());
+
+            return builder;
+        }
+
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public Long getVersionNumber() {
+            return versionNumber;
+        }
+
+        public void setVersionNumber(Long versionNumber) {
+            this.versionNumber = versionNumber;
+        }
+
+        @Override
+        public String getDocumentId() {
+            return documentId;
+        }
+
+        public void setDocumentId(String documentId) {
+            this.documentId = documentId;
+        }
+
+        @Override
+        public String getDocumentTypeId() {
+            return documentTypeId;
+        }
+
+        public void setDocumentTypeId(String documentTypeId) {
+            this.documentTypeId = documentTypeId;
+        }
+
+        @Override
+        public String getDocRouteStatus() {
+            return docRouteStatus;
+        }
+
+        public void setDocRouteStatus(String docRouteStatus) {
+            this.docRouteStatus = docRouteStatus;
+        }
+
+        @Override
+        public Timestamp getFinalizedDate() {
+            return finalizedDate;
+        }
+
+        public void setFinalizedDate(Timestamp finalizedDate) {
+            this.finalizedDate = finalizedDate;
+        }
+
+    }
+
+
+    static class Constants {
+        final static String ROOT_ELEMENT_NAME = "documentRouteHeaderValue";
+        // This has to be different than the org version
+        final static String TYPE_NAME = "DocumentRouteHeaderValueEboImpl";
+    }
+
+
+    static class Elements {
+        final static String ID = "id";
+        final static String DOCUMENT_ID = "documentId";
+        final static String DOCUMENT_TYPE_ID = "documentTypeId";
+        final static String DOC_ROUTE_STATUS = "docRouteStatus";
+        final static String FINALIZED_DATE = "finalizedDate";
+    }
+
+}

--- a/rice-middleware/kew/api/src/main/java/edu/arizona/rice/kew/api/routeheader/DocumentRouteHeaderValueContract.java
+++ b/rice-middleware/kew/api/src/main/java/edu/arizona/rice/kew/api/routeheader/DocumentRouteHeaderValueContract.java
@@ -1,0 +1,15 @@
+package edu.arizona.rice.kew.api.routeheader;
+
+import org.kuali.rice.core.api.mo.common.Identifiable;
+import org.kuali.rice.core.api.mo.common.Versioned;
+
+public interface DocumentRouteHeaderValueContract extends Identifiable, Versioned {
+
+    String getDocumentId();
+
+    String getDocumentTypeId();
+
+    String getDocRouteStatus();
+
+    java.sql.Timestamp getFinalizedDate();
+}


### PR DESCRIPTION
This PR should be merged at the same time as the related UAF-66 KFS PR.

This PR contains extensions to enable the DocumentRouteHeaderValue into an Externalizable BO, so that it can be served over the KSB to KFS. Please see UAF-66 in jira for the full technical details.