### PR TITLE
UAF-66 - Changing header EBO mechanism to not break generic doc search.

### DIFF
--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEboImpl.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kew/routeheader/DocumentRouteHeaderValueEboImpl.java
@@ -1,18 +1,43 @@
 package edu.arizona.rice.kew.routeheader;
 
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.kuali.rice.krad.bo.DataObjectBase;
+import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
 
 import edu.arizona.rice.kew.api.routeheader.DocumentRouteHeaderValueContract;
 
 /**
- * This class is overriden in order to expose DocumentRouteHeaderValue as an
- * Externalizable Business Object (EBO). This then makes the underlying BO
- * avaiable to the KSB, thus available to KFS while Rice is in standalone
- * mode.
+ * This class exposes several fields of DocumentRouteHeaderValue as an
+ * Externalizable Business Object (EBO). This is then made avaiable
+ * on the KSB, thus available to KFS while Rice is in standalone mode.
  */
 @Entity
-public class DocumentRouteHeaderValueEboImpl extends org.kuali.rice.kew.routeheader.DocumentRouteHeaderValue implements DocumentRouteHeaderValueEbo, DocumentRouteHeaderValueContract {
+@Table(name="KREW_DOC_HDR_T")
+public class DocumentRouteHeaderValueEboImpl extends DataObjectBase implements DocumentRouteHeaderValueEbo, DocumentRouteHeaderValueContract {
     private static final long serialVersionUID = 4527977459578527106L;
+
+    @Id
+    @GeneratedValue(generator = "KREW_DOC_HDR_S")
+    @PortableSequenceGenerator(name = "KREW_DOC_HDR_S")
+    @Column(name = "DOC_HDR_ID", nullable = false)
+    private String documentId;
+
+    @Column(name = "DOC_TYP_ID")
+    private String documentTypeId;
+
+    @Column(name = "DOC_HDR_STAT_CD", nullable = false)
+    private String docRouteStatus;
+
+    @Column(name = "FNL_DT")
+    private Timestamp finalizedDate;
+
 
     public static edu.arizona.rice.kew.api.routeheader.DocumentRouteHeaderValue to(DocumentRouteHeaderValueEboImpl documentRouteHeaderValue) {
         if (documentRouteHeaderValue == null) {
@@ -40,8 +65,64 @@ public class DocumentRouteHeaderValueEboImpl extends org.kuali.rice.kew.routehea
 
 
     @Override
+    public String getDocumentId() {
+        return documentId;
+    }
+
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
+
+
+    @Override
+    public String getDocumentTypeId() {
+        return documentTypeId;
+    }
+
+
+    public void setDocumentTypeId(String documentTypeId) {
+        this.documentTypeId = documentTypeId;
+    }
+
+
+    @Override
+    public String getDocRouteStatus() {
+        return docRouteStatus;
+    }
+
+
+    public void setDocRouteStatus(String docRouteStatus) {
+        this.docRouteStatus = docRouteStatus;
+    }
+
+
+    @Override
+    public Timestamp getFinalizedDate() {
+        return finalizedDate;
+    }
+
+
+    public void setFinalizedDate(Timestamp finalizedDate) {
+        this.finalizedDate = finalizedDate;
+    }
+
+
+    @Override
     public String getId() {
         return getDocumentId();
+    }
+
+
+    @SuppressWarnings("unused")
+    public void setId(String id) {
+        // Present due to interface, but we don't use it
+    }
+
+
+    @Override
+    public void refresh() {
+        // DocumentRouteHeaderValue has an empty impl, and so will we
     }
 
 }

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/routeheader/DocumentRouteHeaderValue.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/routeheader/DocumentRouteHeaderValue.java
@@ -69,7 +69,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
-import javax.persistence.MappedSuperclass;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
 import javax.persistence.NamedEntityGraphs;
@@ -125,7 +124,6 @@ import java.util.Map;
  */
 @Entity
 @Table(name="KREW_DOC_HDR_T")
-@MappedSuperclass
 @NamedQueries({
     @NamedQuery(name=QuickLinksDAOJpa.FIND_WATCHED_DOCUMENTS_BY_INITIATOR_WORKFLOW_ID_NAME,
             query= QuickLinksDAOJpa.FIND_WATCHED_DOCUMENTS_BY_INITIATOR_WORKFLOW_ID_QUERY),


### PR DESCRIPTION
Reverting rice foundation class back to pristine (removed on annotation the last PR added). Changing ua header class to not extend foundation's header class in order to get past JPA inheritance handling issues, and gave the ua header class JPA of its own.