### PR TITLE
UAF-5589 Fixes to CurrencyFormatter to allow for custom EIRT doc search

### DIFF
--- a/rice-middleware/core/api/src/main/java/org/kuali/rice/core/web/format/CurrencyFormatter.java
+++ b/rice-middleware/core/api/src/main/java/org/kuali/rice/core/web/format/CurrencyFormatter.java
@@ -19,6 +19,7 @@ package org.kuali.rice.core.web.format;
 
 // begin Kuali Foundation modification
 
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -200,6 +201,10 @@ public class CurrencyFormatter extends Formatter {
 
                 // Note that treating the number as a KualiDecimal below is obsolete. But it doesn't do any harm either since
                 // we already set maximumFractionDigits above.
+            }
+            //UAF-5589 This else if statement is used to prevent a ClassCastException when performing a custom doc search on EIRT
+            else if (obj instanceof BigDecimal) {
+                number = (BigDecimal) obj;
             }
             else {
                 number = (KualiDecimal) obj;


### PR DESCRIPTION
Made the following change to the **format()** method in   **rice-middleware/core/api/src/main/java/org/kuali/rice/core/web/format/CurrencyFormatter.java**

1)  **java.lang.ClassCastException when performing custom EIRT doc search**-  The object being passed into the **format()** method represents the EIRT grandTotalAmount.  This amount is an instance of BigDecimal.  Since a BigDecimal can't be cast to a KualiDecimal, I added an else if clause to check the instance of the object before casting it.