### PR TITLE
UAF-1030 Person Maintenance Doc Incorrect info populating fields

### DIFF
--- a/rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml
+++ b/rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml
@@ -260,7 +260,6 @@
     	"[documentClass].hidden".  The value of this should be a comma delimited list of the DD names of the fields.
      -->
     <param name="kim.enable.history">false</param>
-    <param name="org.kuali.rice.kim.bo.ui.PersonDocumentEmploymentInfo.hidden" override="false">baseSalaryAmount</param>
 	  <param name="kim.hide.PersonDocumentAddress.type" override="false">HM</param>
 	  <param name="kim.hide.PersonDocumentPhone.type" override="false">HM</param>
 


### PR DESCRIPTION
1) Removing config line in **rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml** that turns display off salary field in KIM. 

**This was a problem that was fixed by Scott in KFS6 and was somehow not brought over to KFS7.