### PR TITLE
UAF-2561 Person Maint. Doc read only fields are editable

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java
@@ -845,12 +845,11 @@ public class UiDocumentServiceImpl implements UiDocumentService {
 	@Override
     public boolean canModifyEntity( String currentUserPrincipalId, String toModifyPrincipalId ){
 		return (StringUtils.isNotBlank(currentUserPrincipalId) && StringUtils.isNotBlank(toModifyPrincipalId) &&
-				currentUserPrincipalId.equals(toModifyPrincipalId)) ||
 				getPermissionService().isAuthorized(
 						currentUserPrincipalId,
 						KimConstants.NAMESPACE_CODE,
 						KimConstants.PermissionNames.MODIFY_ENTITY,
-						Collections.singletonMap(KimConstants.AttributeConstants.PRINCIPAL_ID, currentUserPrincipalId));
+						Collections.singletonMap(KimConstants.AttributeConstants.PRINCIPAL_ID, currentUserPrincipalId)));
 	}
 
 	@Override


### PR DESCRIPTION
1) Fixed **rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java** so that no user should be able to edit their own personal record (except the Membership tab).

**Note that these changes were made in KFS6 but they somehow were not brought over into KFS7