### PR TITLE
UAF-5831 - Correcting edge case where role members get deleted from role doc on reload.

### DIFF
--- a/rice-middleware/impl/src/main/java/edu/arizona/rice/kim/service/impl/UaUiDocumentServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/edu/arizona/rice/kim/service/impl/UaUiDocumentServiceImpl.java
@@ -188,4 +188,16 @@ public class UaUiDocumentServiceImpl extends UiDocumentServiceImpl {
         return pndMembers;
     }
 
+
+    @Override
+    protected void updateRoleMembers( String roleId, String kimTypeId, List<KimDocumentRoleMember> modifiedRoleMembers, List<RoleMemberBo> roleMembers){
+        super.updateRoleMembers(roleId, kimTypeId, modifiedRoleMembers, roleMembers);
+
+        // If this is not cleared, they are later assumed by super.setMembersInDocument() as inactivations,
+        // will then get removed from the parent document, and subsequently deleted from the DB during the next
+        // save of the parent document (this only happens w/ IdentityManagementRoleDocument.save() and then
+        // directly after hitting reload button of same doc).
+        modifiedRoleMembers.clear();
+    }
+
 }


### PR DESCRIPTION
This PR corrects an issue when a Role Member Document gets submitted, goes to final, that doc being manually reloaded, and the new role members were being incidentally deleted from the DB.

Please see the jira for full detail.