### PR TITLE
UAF-6458 Immediate action list email formatting in KFS7 is not the sa…

### DIFF
--- a/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/mail/defaultEmailStyle.xsl
+++ b/rice-middleware/impl/src/main/resources/org/kuali/rice/kew/mail/defaultEmailStyle.xsl
@@ -35,7 +35,8 @@
     <xsl:template match="immediateReminder">
         <xsl:variable name="docHandlerUrl" select="actionItem/actionItem/docHandlerURL"/>
         <email>
-            <subject>Action List Reminder <xsl:value-of select="actionItem/customSubject"/></subject>
+            <subject>Action List Reminder - <xsl:value-of select="actionItem/doc/routeStatusLabel"/> - <xsl:value-of select="actionItem/actionItem/actionRequestLabel"/>
+            <xsl:value-of select="actionItem/customSubject"/></subject>
             <body>Your Action List has an eDoc(electronic document) that needs your attention:
 
 Document ID:&tab;<xsl:value-of select="actionItem/actionItem/documentId"/>

--- a/rice-middleware/kew/api/src/main/java/org/kuali/rice/kew/api/action/ActionItem.java
+++ b/rice-middleware/kew/api/src/main/java/org/kuali/rice/kew/api/action/ActionItem.java
@@ -23,6 +23,7 @@ import org.kuali.rice.core.api.delegation.DelegationType;
 import org.kuali.rice.core.api.mo.AbstractDataTransferObject;
 import org.kuali.rice.core.api.mo.ModelBuilder;
 import org.kuali.rice.core.api.util.jaxb.DateTimeAdapter;
+import org.kuali.rice.kew.api.util.CodeTranslator;
 import org.w3c.dom.Element;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -165,6 +166,10 @@ public final class ActionItem
     @Override
     public String getActionRequestId() {
         return this.actionRequestId;
+    }
+    
+    public String getActionRequestLabel() {
+    	return CodeTranslator.getActionRequestLabel(getActionRequestCd());
     }
 
     @Override


### PR DESCRIPTION
…me as KFS3

Modified defaultEmailStyle.xsl to add the missing route status and action request to the immediate reminder email subject.
Modified ActionItem.java to add method getActionRequestLabel. This will make it so the action request label is included with the data being sent for the email.