### PR TITLE
UAR-2075 Comment out jsp directive to allow xml ingester form to access the csrf token.

### DIFF
--- a/rice-middleware/web/src/main/webapp/core/WEB-INF/jsp/impex/ingester.jsp
+++ b/rice-middleware/web/src/main/webapp/core/WEB-INF/jsp/impex/ingester.jsp
@@ -17,7 +17,7 @@
 --%>
 <%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
 
-<%@ page session="false" %>
+<%--<%@ page session="false" %> --%>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Iterator" %>
 


### PR DESCRIPTION
See https://jira.kuali.org/browse/KULRICE-14287.  It appears that foundation ticket is still open.  Checking through the rice code for KFS, the jsp directive was commented out.