### PR TITLE
FIN-294 - Correct EDS employment info / affiliation association

### DIFF
--- a/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/ldap/UaEntityEmploymentMapper.java
+++ b/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/ldap/UaEntityEmploymentMapper.java
@@ -17,7 +17,6 @@ import org.kuali.rice.kim.api.identity.employment.EntityEmployment;
 import org.springframework.ldap.core.DirContextOperations;
 
 import edu.arizona.kim.eds.UaEdsAffiliation;
-import edu.arizona.kim.eds.UaEdsConstants;
 import edu.arizona.kim.eds.UaEdsRecord;
 import edu.arizona.kim.eds.UaEdsRecordFactory;
 
@@ -111,8 +110,7 @@ public class UaEntityEmploymentMapper extends UaBaseMapper<List<EntityEmployment
             return "LDAP context was null!";
         }
 
-        UaEdsConstants edsConstants = new UaEdsConstants();
-        String netIdContextKey = edsConstants.getUidContextKey();
+        String netIdContextKey = getEdsConstants().getUidContextKey();
         String netId = context.getStringAttribute(netIdContextKey);
         if (StringUtils.isBlank(netId)) {
             return "Could not find uid in LDAP context";

--- a/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/ldap/UaEntityEmploymentMapper.java
+++ b/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/ldap/UaEntityEmploymentMapper.java
@@ -18,121 +18,131 @@ import edu.arizona.kim.eds.UaEdsAffiliation;
 import edu.arizona.kim.eds.UaEdsRecord;
 import edu.arizona.kim.eds.UaEdsRecordFactory;
 
+
+
 /**
  * Created by shaloo & kosta on 8/20/15.
  */
 public class UaEntityEmploymentMapper extends UaBaseMapper<List<EntityEmployment>> {
 
-	private static final Logger LOG = Logger.getLogger(UaEntityEmploymentMapper.class);
+    private static final Logger LOG = Logger.getLogger(UaEntityEmploymentMapper.class);
 
-	private ParameterService parameterService;
-	private UaEntityAffiliationMapper affiliationMapper;
-
-	@Override
-	List<EntityEmployment> mapDtoFromContext(DirContextOperations context) {
-		List<EntityEmployment.Builder> builders = mapBuilderFromContext(context);
-		List<EntityEmployment> employments = new ArrayList<EntityEmployment>();
-		if (builders != null) {
-			for (EntityEmployment.Builder builder : builders) {
-				employments.add(builder.build());
-			}
-		}
-
-		return employments;
-	}
-
-	List<EntityEmployment.Builder> mapBuilderFromContext(DirContextOperations context) {
-
-		UaEdsRecord edsRecord = UaEdsRecordFactory.getEdsRecord(context);
-		if (edsRecord == null) {
-			LOG.debug("No active and valid EDS eduPersonAffiliation found for context: " + context.getAttributes());
-			return null;
-		}
-
-		List<EntityEmployment.Builder> employments = new ArrayList<EntityEmployment.Builder>();
-
-		int affId = 1; // The affiliation id is just its position in the ordered
-						// set
-
-		for (UaEdsAffiliation edsAff : edsRecord.getOrderedAffiliations()) {
-
-			// Non-employees don't have employment info, like student or retiree
-			Set<String> nonEmployeeAffs = getValueSetForParameter(getEdsConstants().getEdsNonEmployeeAffsParamKey());
-			if (nonEmployeeAffs.contains(edsAff.getAffiliatonString())) {
-				continue;
-			}
-
-			final EntityEmployment.Builder employmentInfo = EntityEmployment.Builder.create();
-
-			if (affId == 1) {
-				// this is the primary affiliation
-				employmentInfo.setPrimary(true);
-			} else {
-				// This field defaults as 'true' when instantiated, so
-				// explicitly set to false
-				employmentInfo.setPrimary(false);
-			}
-
-			List<EntityAffiliation.Builder> affiliations = getAffiliationMapper().mapBuilderFromContext(context);
-			// only map affiliation if it exists
-			if (affiliations.size() > 0) {
-				employmentInfo.setEntityAffiliation(affiliations.get(0));
-			}
-
-			employmentInfo.setEmploymentRecordId(Integer.toString(affId));
-			employmentInfo.setEmployeeId(edsRecord.getEmplId());
-			employmentInfo.setActive(edsAff.isActive());
-			employmentInfo.setEmployeeStatus(CodedAttribute.Builder.create(edsAff.getStatusCode()));
-			employmentInfo.setPrimaryDepartmentCode(getConstants().getDefaultChartCode() + "-" + edsAff.getDeptCode());
-			employmentInfo.setEmployeeType(CodedAttribute.Builder.create(edsAff.getEmployeeType()));
-
-			// UAF-1030 -- baseSalaryAmount should always show $0.00, and *not* mapped to the EDS value
-			employmentInfo.setBaseSalaryAmount(KualiDecimal.ZERO);
-
-			employments.add(employmentInfo);
-			affId++;
-		}
+    private ParameterService parameterService;
+    private UaEntityAffiliationMapper affiliationMapper;
 
 
-		return employments;
+    @Override
+    List<EntityEmployment> mapDtoFromContext(DirContextOperations context) {
+        List<EntityEmployment.Builder> builders = mapBuilderFromContext(context);
+        List<EntityEmployment> employments = new ArrayList<EntityEmployment>();
+        if (builders != null) {
+            for (EntityEmployment.Builder builder : builders) {
+                employments.add(builder.build());
+            }
+        }
 
-	}
+        return employments;
+    }
 
-	private Set<String> getValueSetForParameter(String parameterKey) {
-		String listAsCommaString = getStringForParameter(parameterKey);
-		String[] listAsArray = listAsCommaString.split(getEdsConstants().getKfsParamDelimiter());
-		Set<String> resultSet = new HashSet<String>();
-		for (String result : listAsArray) {
-			resultSet.add(result);
-		}
-		return resultSet;
-	}
 
-	private String getStringForParameter(String parameterKey) {
-		String namespaceCode = getEdsConstants().getParameterNamespaceCode();
-		String detailTypeCode = getEdsConstants().getParameterDetailTypeCode();
-		Parameter parameter = getParameterService().getParameter(namespaceCode, detailTypeCode, parameterKey);
-		if (parameter == null) {
-			String message = String.format("ParameterService returned null for parameterKey: '%s', namespaceCode: '%s', detailTypeCode: '%s'", parameterKey, namespaceCode, detailTypeCode);
-			throw new RuntimeException(message);
-		}
-		return parameter.getValue();
-	}
+    List<EntityEmployment.Builder> mapBuilderFromContext(DirContextOperations context) {
 
-	private ParameterService getParameterService() {
-		return parameterService;
-	}
+        UaEdsRecord edsRecord = UaEdsRecordFactory.getEdsRecord(context);
+        if (edsRecord == null) {
+            LOG.debug("No active and valid EDS eduPersonAffiliation found for context: " + context.getAttributes());
+            return null;
+        }
 
-	public void setParameterService(ParameterService parameterService) {
-		this.parameterService = parameterService;
-	}
+        List<EntityEmployment.Builder> employments = new ArrayList<EntityEmployment.Builder>();
 
-	public final UaEntityAffiliationMapper getAffiliationMapper() {
-		return this.affiliationMapper;
-	}
+        int affId = 1; // The affiliation id is just its position in the ordered
+        // set
 
-	public void setAffiliationMapper(UaEntityAffiliationMapper entityAffiliationMapper) {
-		this.affiliationMapper = entityAffiliationMapper;
-	}
+        for (UaEdsAffiliation edsAff : edsRecord.getOrderedAffiliations()) {
+
+            // Non-employees don't have employment info, like student or retiree
+            Set<String> nonEmployeeAffs = getValueSetForParameter(getEdsConstants().getEdsNonEmployeeAffsParamKey());
+            if (nonEmployeeAffs.contains(edsAff.getAffiliatonString())) {
+                continue;
+            }
+
+            final EntityEmployment.Builder employmentInfo = EntityEmployment.Builder.create();
+
+            if (affId == 1) {
+                // this is the primary affiliation
+                employmentInfo.setPrimary(true);
+            } else {
+                // This field defaults as 'true' when instantiated, so
+                // explicitly set to false
+                employmentInfo.setPrimary(false);
+            }
+
+            List<EntityAffiliation.Builder> affiliations = getAffiliationMapper().mapBuilderFromContext(context);
+            // only map affiliation if it exists
+            if (affiliations.size() > 0) {
+                employmentInfo.setEntityAffiliation(affiliations.get(0));
+            }
+
+            employmentInfo.setEmploymentRecordId(Integer.toString(affId));
+            employmentInfo.setEmployeeId(edsRecord.getEmplId());
+            employmentInfo.setActive(edsAff.isActive());
+            employmentInfo.setEmployeeStatus(CodedAttribute.Builder.create(edsAff.getStatusCode()));
+            employmentInfo.setPrimaryDepartmentCode(getConstants().getDefaultChartCode() + "-" + edsAff.getDeptCode());
+            employmentInfo.setEmployeeType(CodedAttribute.Builder.create(edsAff.getEmployeeType()));
+
+            // UAF-1030 -- baseSalaryAmount should always show $0.00, and *not* mapped to the EDS value
+            employmentInfo.setBaseSalaryAmount(KualiDecimal.ZERO);
+
+            employments.add(employmentInfo);
+            affId++;
+        }
+
+
+        return employments;
+
+    }
+
+
+    private Set<String> getValueSetForParameter(String parameterKey) {
+        String listAsCommaString = getStringForParameter(parameterKey);
+        String[] listAsArray = listAsCommaString.split(getEdsConstants().getKfsParamDelimiter());
+        Set<String> resultSet = new HashSet<String>();
+        for (String result : listAsArray) {
+            resultSet.add(result);
+        }
+        return resultSet;
+    }
+
+
+    private String getStringForParameter(String parameterKey) {
+        String namespaceCode = getEdsConstants().getParameterNamespaceCode();
+        String detailTypeCode = getEdsConstants().getParameterDetailTypeCode();
+        Parameter parameter = getParameterService().getParameter(namespaceCode, detailTypeCode, parameterKey);
+        if (parameter == null) {
+            String message = String.format("ParameterService returned null for parameterKey: '%s', namespaceCode: '%s', detailTypeCode: '%s'", parameterKey, namespaceCode, detailTypeCode);
+            throw new RuntimeException(message);
+        }
+        return parameter.getValue();
+    }
+
+
+    private ParameterService getParameterService() {
+        return parameterService;
+    }
+
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+
+    public final UaEntityAffiliationMapper getAffiliationMapper() {
+        return this.affiliationMapper;
+    }
+
+
+    public void setAffiliationMapper(UaEntityAffiliationMapper entityAffiliationMapper) {
+        this.affiliationMapper = entityAffiliationMapper;
+    }
 
 }

--- a/rice-middleware/kim/kim-ldap/src/main/resources/org/kuali/rice/kim/config/UaKIMLdapSpringBeans.xml
+++ b/rice-middleware/kim/kim-ldap/src/main/resources/org/kuali/rice/kim/config/UaKIMLdapSpringBeans.xml
@@ -33,7 +33,7 @@
         <property name="credentials" value="${rice.ldap.password}" />
     </bean>
 
-    <bean id="edsConstants" class="edu.arizona.kim.eds.UaEdsConstants" scope="prototype">
+    <bean id="edsConstants" class="edu.arizona.kim.eds.UaEdsConstants" >
         <!-- Keys into the EDS Schema -->
         <property name="uaIdContextKey"                                value="uaId" />
         <property name="uidContextKey"                                 value="uid" />

--- a/rice-middleware/kim/kim-ldap/src/main/resources/org/kuali/rice/kim/config/UaKIMLdapSpringBeans.xml
+++ b/rice-middleware/kim/kim-ldap/src/main/resources/org/kuali/rice/kim/config/UaKIMLdapSpringBeans.xml
@@ -33,7 +33,7 @@
         <property name="credentials" value="${rice.ldap.password}" />
     </bean>
 
-    <bean id="edsConstants" class="edu.arizona.kim.eds.UaEdsConstants">
+    <bean id="edsConstants" class="edu.arizona.kim.eds.UaEdsConstants" scope="prototype">
         <!-- Keys into the EDS Schema -->
         <property name="uaIdContextKey"                                value="uaId" />
         <property name="uidContextKey"                                 value="uid" />


### PR DESCRIPTION
These changes sync the conversion of a list of EDS affiliation POJO with a list of the Kuali analog POJO via introducing a new index for the former. This ensures each employment info gets matched up with its related affiliation.