### PR TITLE
FIN-640 : Create Liquibase Files for DB SQL DDL Schema changes for Release 50.

### DIFF
--- a/db/edu/arizona/changelog/changesets/db.changelog-FIN-640-KULRICE-14144.xml
+++ b/db/edu/arizona/changelog/changesets/db.changelog-FIN-640-KULRICE-14144.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="FIN-640-KULRICE-14144" author="Jim Reese">
+        <comment>
+            db.changelog-FIN-640-KULRICE-14144.xml : Create Liquibase Files for DB SQL DDL Schema changes for Release 50.
+            This Liquibase contains the foundation Rice 2.6.0 DB upgrade SQL script '2015-03-10--KULRICE-14144.sql'
+            some of which required modification to work with the existing UA KFS7/Rice DB, the UACustomized statements
+            have been commented as such. Also replaced all '/' statement terminators with ';' and wrapped in a
+            liquibase block.
+        </comment>
+        <sql>
+            alter table krsb_qrtz_trigger_listeners drop constraint   KRSB_QRTZ_TRIGGER_LISTENE_TR1;
+            alter table krsb_qrtz_job_details drop column is_volatile;
+            alter table krsb_qrtz_triggers drop column is_volatile;
+            alter table krsb_qrtz_fired_triggers drop column is_volatile;
+            alter table krsb_qrtz_job_details add is_nonconcurrent VARCHAR2(1);
+            alter table krsb_qrtz_job_details add is_update_data VARCHAR2(1);
+            update krsb_qrtz_job_details set is_nonconcurrent = is_stateful;
+            update krsb_qrtz_job_details set is_update_data = is_stateful;
+            alter table krsb_qrtz_job_details drop column is_stateful;
+            alter table krsb_qrtz_fired_triggers add is_nonconcurrent VARCHAR2(1);
+            alter table krsb_qrtz_fired_triggers add is_update_data VARCHAR2(1);
+            update krsb_qrtz_fired_triggers set is_nonconcurrent = is_stateful;
+            update krsb_qrtz_fired_triggers set is_update_data = is_stateful;
+            alter table krsb_qrtz_fired_triggers drop column is_stateful;
+            alter table krsb_qrtz_blob_triggers add sched_name varchar(120) DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_calendars add sched_name varchar(120) DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_cron_triggers add sched_name varchar(120) DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_fired_triggers add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null;
+            ALTER TABLE KRSB_QRTZ_FIRED_TRIGGERS ADD SCHED_TIME NUMBER(13) DEFAULT 1540230164677 NOT NULL;  -- UACustom added DEFAULT 1540230164677 to apply NOT NULL column to a non empty table, the SCHED_TIME value used was the FIRED_TIME value of the only row already existing in the table
+            alter table krsb_qrtz_job_details add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_locks add sched_name varchar(120) DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_paused_trigger_grps add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_scheduler_state add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_simple_triggers add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_triggers add sched_name varchar(120) DEFAULT 'KrTestScheduler' not null;
+            alter table krsb_qrtz_blob_triggers drop constraint KRSB_QRTZ_BLOB_TRIGGERS_TR1;
+            alter table krsb_qrtz_cron_triggers drop constraint KRSB_QRTZ_CRON_TRIGGERS_TR1;
+            ALTER TABLE KRSB_QRTZ_JOB_DETAILS DROP CONSTRAINT PKKRSB_QRTZ_JOB_DETAILS;     -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_JOB_DETAILS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_job_details add constraint KRSB_QRTZ_JOB_DETAILSP1 primary key (job_name, job_group, sched_name);
+            ALTER TABLE KRSB_QRTZ_TRIGGERS DROP CONSTRAINT PKKRSB_QRTZ_TRIGGERS;     -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_TRIGGERS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_triggers add constraint KRSB_QRTZ_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name);
+            alter table krsb_qrtz_triggers add constraint KRSB_QRTZ_TRIGGERS_TR1 foreign key (job_name, job_group, sched_name) references krsb_qrtz_job_details(job_name, job_group, sched_name);
+            ALTER TABLE KRSB_QRTZ_BLOB_TRIGGERS DROP CONSTRAINT PKKRSB_QRTZ_BLOB_TRIGGERS;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_BLOB_TRIGGERS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_blob_triggers add constraint KRSB_QRTZ_BLOB_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name);
+            alter table krsb_qrtz_blob_triggers add constraint KRSB_QRTZ_BLOB_TRIGGERS_TR1 foreign key (trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name);
+            ALTER TABLE KRSB_QRTZ_CRON_TRIGGERS DROP CONSTRAINT PKKRSB_QRTZ_CRON_TRIGGERS;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_CRON_TRIGGERS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_cron_triggers add constraint KRSB_QRTZ_CRON_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name);
+            alter table krsb_qrtz_cron_triggers add constraint KRSB_QRTZ_CRON_TRIGGERS_TR1 foreign key (trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name);
+            ALTER TABLE KRSB_QRTZ_SIMPLE_TRIGGERS DROP CONSTRAINT PKKRSB_QRTZ_SIMPLE_TRIGGERS;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_SIMPLE_TRIGGERS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_simple_triggers add constraint KRSB_QRTZ_SIMPLE_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name);
+            alter table krsb_qrtz_simple_triggers add constraint KRSB_QRTZ_SIMPLE_TRIGGERS_TR1 foreign key (trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name);
+            ALTER TABLE KRSB_QRTZ_FIRED_TRIGGERS DROP CONSTRAINT PKKRSB_QRTZ_FIRED_TRIGGERS;     -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_FIRED_TRIGGERS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_fired_triggers add constraint KRSB_QRTZ_FIRED_TRIGGERSP1 primary key (entry_id, sched_name);
+            ALTER TABLE KRSB_QRTZ_CALENDARS DROP CONSTRAINT PKKRSB_QRTZ_CALENDARS;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_CALENDARS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_calendars add constraint KRSB_QRTZ_CALENDARSP1 primary key (calendar_name, sched_name);
+            ALTER TABLE KRSB_QRTZ_LOCKS DROP CONSTRAINT PKKRSB_QRTZ_LOCKS;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_LOCKS;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_locks add constraint KRSB_QRTZ_LOCKSP1 primary key (lock_name, sched_name);
+            ALTER TABLE KRSB_QRTZ_PAUSED_TRIGGER_GRPS DROP CONSTRAINT PKKRSB_QRTZ_PAUSED_TRIGGER_GR;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX PKKRSB_QRTZ_PAUSED_TRIGGER_GR;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_paused_trigger_grps add constraint KRSB_QRTZ_PAUSED_TRIGGER_GRP1 primary key (trigger_group, sched_name);
+            ALTER TABLE KRSB_QRTZ_SCHEDULER_STATE DROP CONSTRAINT PKKRSB_QRTZ_SCHEDULER_STATE;        -- UACustom changed primary key constraint name to be dropped to the existing UA primary key constraint name
+            DROP INDEX RICE.PKKRSB_QRTZ_SCHEDULER_STATE;         -- UACustom drop the explicit Unique Constraint Index created from implicit Unique Constraint of primary key dropped above
+            alter table krsb_qrtz_scheduler_state add constraint KRSB_QRTZ_SCHEDULER_STATEP1 primary key (instance_name, sched_name);
+            CREATE TABLE krsb_qrtz_simprop_triggers
+            (
+            SCHED_NAME VARCHAR2(120) NOT NULL,
+            TRIGGER_NAME VARCHAR2(200) NOT NULL,
+            TRIGGER_GROUP VARCHAR2(200) NOT NULL,
+            STR_PROP_1 VARCHAR2(512) NULL,
+            STR_PROP_2 VARCHAR2(512) NULL,
+            STR_PROP_3 VARCHAR2(512) NULL,
+            INT_PROP_1 NUMBER(10) NULL,
+            INT_PROP_2 NUMBER(10) NULL,
+            LONG_PROP_1 NUMBER(13) NULL,
+            LONG_PROP_2 NUMBER(13) NULL,
+            DEC_PROP_1 NUMERIC(13,4) NULL,
+            DEC_PROP_2 NUMERIC(13,4) NULL,
+            BOOL_PROP_1 VARCHAR2(1) NULL,
+            BOOL_PROP_2 VARCHAR2(1) NULL,
+            constraint KRSB_QRTZ_SIMPROP_TRIGGERSP1 primary key (SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP),
+            constraint KRSB_QRTZ_SIMPROP_TRIGGERS_TR1 foreign key (SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP)
+            references KRSB_QRTZ_TRIGGERS(TRIGGER_NAME,TRIGGER_GROUP, SCHED_NAME)
+            );
+        </sql>
+        <rollback>
+            <sql>
+            </sql>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/db/edu/arizona/changelog/changesets/db.changelog-FIN-640-KULRICE-14217.xml
+++ b/db/edu/arizona/changelog/changesets/db.changelog-FIN-640-KULRICE-14217.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="FIN-640-KULRICE-14217" author="Jim Reese">
+        <comment>
+            db.changelog-FIN-640-KULRICE-14217 : Create Liquibase Files for DB SQL DDL Schema changes for Release 50.
+            This Liquibase replaces foundation Rice 2.6.0 DB upgrade SQL script: '2015-05-12--KULRICE-14217.sql' which
+            required no modification to work with the UA KFS7 DB other than changing '/' statement terminators with ';'
+            and wrapping in a liquibase block.
+        </comment>
+        <sql>
+            CREATE TABLE KREW_ACTN_ITM_CHANGED_T
+            (
+            ACTN_TYP VARCHAR2(1),
+            ACTN_ITM_ID VARCHAR2(40),
+            PRIMARY KEY(ACTN_ITM_ID, ACTN_TYP)
+            );
+
+            CREATE OR REPLACE TRIGGER actn_item_changed
+            AFTER INSERT OR UPDATE OR DELETE ON KREW_ACTN_ITM_T
+            FOR EACH ROW
+            BEGIN
+            -- Use 'I' for an INSERT, 'U' for UPDATE, and 'D' for DELETE
+            IF INSERTING THEN
+            INSERT INTO KREW_ACTN_ITM_CHANGED_T VALUES ('I', :NEW.ACTN_ITM_ID);
+            ELSIF UPDATING THEN
+            INSERT INTO KREW_ACTN_ITM_CHANGED_T VALUES ('U', :NEW.ACTN_ITM_ID);
+            ELSE
+            INSERT INTO KREW_ACTN_ITM_CHANGED_T VALUES ('D', :OLD.ACTN_ITM_ID);
+            END IF;
+            END;
+        </sql>
+        <rollback>
+            <sql>
+            </sql>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/db/edu/arizona/changelog/db.changelog-master.xml
+++ b/db/edu/arizona/changelog/db.changelog-master.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog 
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog 
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd"> 
+
+  <!-- Here we will include all changesets in the proper order -->
+  <!-- include file="changesets/db.changelog-UAF-###.xml" -->
+
+  <include file="changesets/db.changelog-FIN-640-KULRICE-14144.xml" />
+  <include file="changesets/db.changelog-FIN-640-KULRICE-14217.xml" />
+
+</databaseChangeLog>


### PR DESCRIPTION
FIN-640 : Create Liquibase Files for DB SQL DDL Schema changes for Release 50. Created Liquibase directories and files 'db/edu/arizona/changelog/db.changelog-master.xml', 'db/edu/arizona/changelog/changesets/db.changelog-FIN-640-KULRICE-14144.xml' and 'db/edu/arizona/changelog/changesets/db.changelog-FIN-640-KULRICE-14217.xml' containing Liquibase to replace foundation Rice 2.6.0 DB upgrade SQL scripts '2015-03-10--KULRICE-14144.sql' (The sql in this file required the modifications noted in comments to run on UA DB) and '2015-05-12--KULRICE-14217.sql' (The sql in this file did not require modification to run on existing UA KFS7/Rice DB) .