### PR TITLE
FIN-535 Changing default to the new 2.6 ua-development branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2629,7 +2629,7 @@
     <developerConnection>scm:git:git@github.com:ua-eas/ksd-kc5.2.1-rice.git</developerConnection>
     <connection>scm:git:git@github.com:ua-eas/ksd-kc5.2.1-rice.git</connection>
     <url>https://github.com/ua-eas/ksd-kc5.2.1-rice/tree/${project.scm.tag}</url>
-    <tag>rice-2.5-ua-development</tag>
+    <tag>rice-2.6-ua-development</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
This fixes build issues in Jenkins since new modules were introduced when we moved from 2.5.19 to 2.6.