### PR TITLE
FIN-1443-sgs - Adding back finalName so resulting war has generic name without version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -672,6 +672,7 @@
   </profiles>
 
   <build>
+    <finalName>${project.artifactId}</finalName>
     <testResources>
       <!-- NOTE: Because Maven test runs can be spawned in a new JVM, the system
         properties on the initial Maven command line are not necessarily propagated


### PR DESCRIPTION
The build property `finalName` was removed from the root pom by upstream.

This results in a war being created that the full project version in it's filename -- this breaks our jenkins deploy job which expects just the generic 'rice-standalone.war'.

Adding back in the property restores the generic name our CI expects.