### PR TITLE
FIN-1443-sgs - Correcting logging statement not printing actual value

### DIFF
--- a/rice-middleware/kim/kim-ldap/src/main/java/org/kuali/rice/kim/dao/impl/LdapPrincipalDaoImpl.java
+++ b/rice-middleware/kim/kim-ldap/src/main/java/org/kuali/rice/kim/dao/impl/LdapPrincipalDaoImpl.java
@@ -151,7 +151,7 @@ public class LdapPrincipalDaoImpl implements LdapPrincipalDao {
         }
         ;
 
-        LOG.info("Using filter ", filter.encode());
+        LOG.info("Using filter " + filter.encode());
 
         List retval = new ArrayList();
 


### PR DESCRIPTION
The BufferedLogger has gone away this release, and when converting over to the plain log4j2 Logger, the value of the LDAP filter is not being printed out (old way was feeding in an arg, not appending).

This PR changes the log message to use appending the arg.