### PR TITLE
FIN-2291 Escape backLocation to prevent cross site scripting

### DIFF
--- a/rice-middleware/kns/src/main/java/org/kuali/rice/kns/util/WebUtils.java
+++ b/rice-middleware/kns/src/main/java/org/kuali/rice/kns/util/WebUtils.java
@@ -962,6 +962,12 @@ public class WebUtils {
     }
 
 	public static String sanitizeBackLocation(String backLocation) {
+
+		//FIN-2291 UA fix to prevent cross site scripting
+		if(StringUtils.isNotBlank(backLocation)){
+			backLocation = StringEscapeUtils.escapeHtml(backLocation);
+		}
+
 		if(StringUtils.isBlank(backLocation)) {
 			return backLocation;
 		}


### PR DESCRIPTION
Escape backLocation to prevent cross site scripting. This touches the Kuali static utility class because it would require the least amount of code changes compared to creating a new UA utility class and changing all code to use this new class.