### PR TITLE
FIN-3151 - Version bumping jackson data-bind, appears to have been missed years ago.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2186,7 +2186,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.2</version>
+        <version>${jackson.version}</version>
         <scope>compile</scope>
       </dependency>
 


### PR DESCRIPTION
Now synced with jackson.version like the other fasterxml libs.