### PR TITLE
FIN-3756 - Correcting parsing of dccRelation string to force retention of empty fields.

### DIFF
--- a/rice-middleware/kim/kim-ldap/pom.xml
+++ b/rice-middleware/kim/kim-ldap/pom.xml
@@ -135,5 +135,11 @@
       <artifactId>rice-impl</artifactId>
       <version>${project.version}</version>
     </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.13.1</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/eds/UaEdsDccRelation.java
+++ b/rice-middleware/kim/kim-ldap/src/main/java/edu/arizona/kim/eds/UaEdsDccRelation.java
@@ -61,7 +61,8 @@ public class UaEdsDccRelation {
 	private String endDate;
 
 	public UaEdsDccRelation(final String dccRelationRecordString) {
-		String[] tokens = dccRelationRecordString.split(DCC_RELATION_DELIM);
+		// The split's '-1' forces keeping trailing empty fields
+		String[] tokens = dccRelationRecordString.split(DCC_RELATION_DELIM, -1);
 		setTitle(tokens[0]);
 		setType(tokens[1]);
 		setDeptCode(tokens[2]);

--- a/rice-middleware/kim/kim-ldap/src/test/java/edu/arizona/kim/eds/UaEdsDccRelationTest.java
+++ b/rice-middleware/kim/kim-ldap/src/test/java/edu/arizona/kim/eds/UaEdsDccRelationTest.java
@@ -1,0 +1,57 @@
+package edu.arizona.kim.eds;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+
+public class UaEdsDccRelationTest {
+    private static final List<String> knownGood;
+    private static final List<String> pastFailures;
+    static {
+        knownGood = new ArrayList<>();
+        knownGood.add("Affiliate:00910:9903:Philanthropy & Alumni Engagement:I:20180730:20190208:NON");
+        knownGood.add("Research Associate:00920:9011:BIO5 Institute:I:20230918:20240630:NON");
+        knownGood.add("Volunteer:00979:1540:County Office - Pima County:I:20200818:20231231:VM");
+        knownGood.add("Volunteer:00979:9011:BIO5 Institute:I:20190416:20190630:");
+
+        pastFailures = new ArrayList<>();
+        pastFailures.add("New Hire- Pending Approval:00995:::I:::");
+        pastFailures.add("Administrative Support Assistant II:00995::Cancer Center Division:I:20240930::");
+        pastFailures.add("New Hire- Pending Approval:00995:3221::I:20240916:19000101:");
+    }
+
+
+    @Test
+    public void testKnownGood() {
+        for (String relation : knownGood) {
+            assertTrue(parsedSuccessfully(relation));
+        }
+    }
+
+
+    @Test
+    public void testPastFailures() {
+        for (String relation : pastFailures) {
+            assertTrue(parsedSuccessfully(relation));
+        }
+    }
+
+
+    private boolean parsedSuccessfully(String relation) {
+        try {
+            new UaEdsDccRelation(relation);
+        } catch (Exception e) {
+            System.out.println("Failed to create relation from string: '" + relation + "'");
+            System.out.println(e.getMessage());
+            return false;
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
Java's default String#split() behavior is to stop parsing and drop all empty fields at the end of the supplied input. Adding a `-1` to the call instructs the regex engine to continue parsing and return all empty tokens as they are found.

The remainder of the code is to pull apply a tests for the cases we have seen fail in the wild, known good cases, and cases with EDS mitigation currently in place (i.e. the EDS team is appending various suffixes to emulate full record).